### PR TITLE
Replace `unidecode` with `anyascii` for license compliance

### DIFF
--- a/docs/source/tokenizer.rst
+++ b/docs/source/tokenizer.rst
@@ -60,7 +60,7 @@ You can override the *normalize* function of a tokenizer to suit your needs.
 The :ref:`api_doc:english_tokenizer` normalizes each token by doing lowercasing.
 The :ref:`api_doc:french_tokenizer` performs lowercasing and remove accents.
 The only difference between the french_tokenizer and the english_tokenizer is the removal of diacritics
-done with the unidecode library that tries to transform the label in ASCII characters.
+done with the `anyascii` library that tries to transform the label in ASCII characters.
 Using the french_tokenizer for english documents adds very little overhead.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 keywords = ["NLP", "semantic annotation", "entity linking"]
-dependencies = ['unidecode>=1.1.1', 'typing-extensions~=4.4.0', 'spellwise>=0.8.0', 'pysimstring~=1.2.1']
+dependencies = ['anyascii>=0.3.2', 'typing-extensions~=4.4.0', 'spellwise>=0.8.0', 'pysimstring~=1.2.1']
 
 [project.optional-dependencies]
 tests = ['nltk>=3.8.0', 'spacy>=3.2.0']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-unidecode>=1.1.1
+anyascii>=0.3.2
 typing-extensions~=4.4.0
 spellwise>=0.8.0
 nltk>=3.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-unidecode>=1.1.1
+anyascii>=0.3.2
 typing-extensions~=4.4.0
 spellwise>=0.8.0
 pysimstring~=1.2.1

--- a/src/iamsystem/tokenization/normalize.py
+++ b/src/iamsystem/tokenization/normalize.py
@@ -1,7 +1,7 @@
 """ String normalization functions. """
 from typing import Callable
 
-from unidecode import unidecode_expect_ascii  # type: ignore
+from anyascii import anyascii  # type: ignore
 
 
 normalizeFun = Callable[[str], str]
@@ -13,6 +13,6 @@ def lower_no_accents(string: str) -> str:
 
 
 def _remove_accents(string: str) -> str:
-    """Remove accents with unidecode library."""
-    unaccented_string: str = unidecode_expect_ascii(string.replace("μ", "u"))
+    """Remove accents with anyascii library."""
+    unaccented_string: str = anyascii(string.replace("μ", "u"))
     return unaccented_string


### PR DESCRIPTION
`iamsystem` is released under a permissive MIT license but depends on `unidecode`, which is a GPL library. Those two have incompatible licensing requirements, which impacts downstream projects using your library such as `medkit`.

This PR proposes to replace `unidecode` with `anyascii`, which is licensed under the ISC license (MIT-like). The latter is designed as a drop-in replacement for the former, and many projects have gone through this transition.

If you accept this PR (and I believe you should), please consider making a new release as soon as you can :pray:   