### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7","3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,12 @@ jobs:
         python-version: ["3.7","3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,18 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 keywords = ["NLP", "semantic annotation", "entity linking"]
-dependencies = ['anyascii>=0.3.2', 'typing-extensions~=4.4.0', 'spellwise>=0.8.0', 'pysimstring~=1.2.1']
+dependencies = [
+    "anyascii>=0.3.2",
+    "typing_extensions>=4.7.0; python_version>='3.12'",
+    "typing_extensions~=4.4.0; python_version<'3.12'",
+    "spellwise>=0.8.0",
+    "pysimstring~=1.2.1",
+]
 
 [project.optional-dependencies]
 tests = ['nltk>=3.8.0', 'spacy>=3.2.0']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 anyascii>=0.3.2
-typing-extensions~=4.4.0
+typing_extensions>=4.7.0; python_version>="3.12"
+typing_extensions~=4.4.0; python_version<"3.12"
 spellwise>=0.8.0
 nltk>=3.8.0
 spacy>=3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 anyascii>=0.3.2
-typing-extensions~=4.4.0
+typing_extensions>=4.7.0; python_version>="3.12"
+typing_extensions~=4.4.0; python_version<"3.12"
 spellwise>=0.8.0
 pysimstring~=1.2.1


### PR DESCRIPTION
When running the `medkit` test suite for Python 3.12, the following error is triggered with importing `iamsystem`:

`TypeError: type ‘typing.TypeVar’ is not an acceptable base type`

This is a bug in `typing_extensions`, which is fixed in a newer release (starting from version 4.7).

This PR updates the project metadata and dependencies to provide support and run tests on Python 3.12.

- Bump minimum version of `typing_extensions` to the one with official support for Python 3.12
- Update trove classifiers in project metadata
- Enable tests for Python 3.12 in CI
- Use setup-python@v5 caching capabilities 