### PR TITLE
Require typing-extensions >= 4.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ classifiers = [
 keywords = ["NLP", "semantic annotation", "entity linking"]
 dependencies = [
     "anyascii>=0.3.2",
-    "typing_extensions>=4.7.0; python_version>='3.12'",
-    "typing_extensions~=4.4.0; python_version<'3.12'",
+    "typing_extensions>=4.7.0",
     "spellwise>=0.8.0",
     "pysimstring~=1.2.1",
 ]


### PR DESCRIPTION
My intuition in #23 proved to be right: bounding typing-extensions to an upper limit of 4.4.0 creates all sorts of issue, such as this [one in medkit](https://github.com/medkit-lib/medkit/issues/40).